### PR TITLE
Fix RealWorld API base URL to api.realworld.show

### DIFF
--- a/app/common/api.ts
+++ b/app/common/api.ts
@@ -1,1 +1,1 @@
-export const BASE_URL = "https://api.realworld.io/api";
+export const BASE_URL = "https://api.realworld.show/api";

--- a/app/components/article/article-preview.tsx
+++ b/app/components/article/article-preview.tsx
@@ -7,7 +7,7 @@ export function ArticlePreview({ article }: { article: ArticleData }) {
     <div className="article-preview">
       <div className="article-meta">
         <Link to={`/profile/${article.author.username}`}>
-          <img src={`${article.author.image}`} />
+          <img src={article.author.image ?? undefined} />
         </Link>
         <div className="info">
           <Link to={`/profile/${article.author.username}`} className="author">

--- a/app/models/author.ts
+++ b/app/models/author.ts
@@ -1,6 +1,6 @@
 export interface AuthorData {
-  image: string;
+  image: string | null;
   username: string;
   following: boolean;
-  bio: string;
+  bio: string | null;
 }

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -1,8 +1,8 @@
 export interface UserData {
   username: string;
   email: string;
-  bio: string;
-  image: string;
+  bio: string | null;
+  image: string | null;
   token: string;
 }
 

--- a/app/routes/article.$slug.tsx
+++ b/app/routes/article.$slug.tsx
@@ -92,7 +92,7 @@ export default function ArticleView() {
 
           <div className="article-meta">
             <Link prefetch="intent" to={`/profile/${article.author.username}`}>
-              <img src={article.author.image} />
+              <img src={article.author.image ?? undefined} />
             </Link>
 
             <div className="info">
@@ -138,7 +138,7 @@ export default function ArticleView() {
         <div className="article-actions">
           <div className="article-meta">
             <Link prefetch="intent" to={`/profile/${article.author.username}`}>
-              <img src={article.author.image} />
+              <img src={article.author.image ?? undefined} />
             </Link>
             <div className="info">
               <Link prefetch="intent" to={`/profile/${article.author.username}`} className="author">
@@ -169,7 +169,7 @@ export default function ArticleView() {
                   <textarea className="form-control" name="comment" placeholder="Write a comment..." rows={3}></textarea>
                 </div>
                 <div className="card-footer">
-                  <img src={userSession.image} className="comment-author-img" />
+                  <img src={userSession.image || undefined} className="comment-author-img" />
                   <button className="btn btn-sm btn-primary" type="submit" name="action" value="CREATE" disabled={navigation.state === "submitting"}>
                     Post Comment
                   </button>
@@ -196,7 +196,7 @@ export default function ArticleView() {
 
                 <div className="card-footer">
                   <Link to={`/profile/${comment.author.username}`} className="comment-author">
-                    <img src={comment.author.image} className="comment-author-img" />
+                    <img src={comment.author.image ?? undefined} className="comment-author-img" />
                   </Link>
                   &nbsp;
                   <Link to={`/profile/${comment.author.username}`} className="comment-author">

--- a/app/routes/profile.$username.tsx
+++ b/app/routes/profile.$username.tsx
@@ -60,7 +60,7 @@ export default function Profile() {
         <div className="container">
           <div className="row">
             <div className="col-xs-12 col-md-10 offset-md-1">
-              <img src={profile.image} className="user-img" />
+              <img src={profile.image ?? undefined} className="user-img" />
               <h4>{profile.username}</h4>
               <p>{profile.bio}</p>
 

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -30,10 +30,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return data({ errors: { "": ["email can't be blank"] } }, { status: 400 });
   }
 
-  if (!validateInput(image)) {
-    return data({ errors: { "": ["image can't be blank"] } }, { status: 400 });
-  }
-
   if (!validateInput(username)) {
     return data({ errors: { "": ["username can't be blank"] } }, { status: 400 });
   }
@@ -78,13 +74,13 @@ export default function Settings() {
             <Form method="post">
               <fieldset>
                 <fieldset className="form-group">
-                  <input className="form-control" type="text" name="image" defaultValue={user.image} placeholder="URL of profile picture" />
+                  <input className="form-control" type="text" name="image" defaultValue={user.image ?? ""} placeholder="URL of profile picture" />
                 </fieldset>
                 <fieldset className="form-group">
                   <input className="form-control form-control-lg" type="text" name="username" defaultValue={user.username} placeholder="Your Name" />
                 </fieldset>
                 <fieldset className="form-group">
-                  <textarea className="form-control form-control-lg" name="bio" defaultValue={user.bio} rows={8} placeholder="Short bio about you"></textarea>
+                  <textarea className="form-control form-control-lg" name="bio" defaultValue={user.bio ?? ""} rows={8} placeholder="Short bio about you"></textarea>
                 </fieldset>
                 <fieldset className="form-group">
                   <input className="form-control form-control-lg" type="text" name="email" defaultValue={user.email} placeholder="Email" />

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -47,13 +47,13 @@ export async function createUserSession({
   request: Request;
   username: string;
   authToken: string;
-  image: string;
+  image?: string | null;
   redirectTo: string;
 }) {
   const session = await getSession(request);
   session.set(USERNAME_KEY, username);
   session.set(TOKEN_KEY, authToken);
-  session.set(IMAGE_KEY, image);
+  session.set(IMAGE_KEY, image ?? "");
   return redirect(redirectTo, {
     headers: {
       "Set-Cookie": await sessionStorage.commitSession(session, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Point the RealWorld client at the new API host `https://api.realworld.show/api` (old `api.realworld.io` is down)
- Allow `null` bio/image values returned by the new API
- Make the settings image field optional and safe for null defaults

## Verification
- `npm run typecheck` passes
- Live checks against `api.realworld.show` succeed for articles, tags, auth, favorite, and follow
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9be0b5d6-4742-4695-9d6a-5db0efc20abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9be0b5d6-4742-4695-9d6a-5db0efc20abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

